### PR TITLE
Remove keep-alive tick from SessionMonitor

### DIFF
--- a/notifications-service/src/main/resources/application.conf
+++ b/notifications-service/src/main/resources/application.conf
@@ -45,8 +45,6 @@ notifications {
   pingInterval = ${?PING_INTERVAL}
   freshnessThreshold = 30
   freshnessThreshold = ${?FRESHNESS_THRESHOLD}
-  keepAliveInterval = 300 # 5 minutes
-  keepAliveInterval = ${?KEEPALIVE_INTERVAL}
   aggregationInterval = 15
   aggregationInterval = ${?AGGREGATION_INTERVAL}
   aggregationCount = 10

--- a/notifications-service/src/test/scala/com/pennsieve/notifications/api/NotificationsBaseSpec.scala
+++ b/notifications-service/src/test/scala/com/pennsieve/notifications/api/NotificationsBaseSpec.scala
@@ -100,10 +100,6 @@ trait NotificationsBaseSpec
         ConfigValueFactory.fromAnyRef(30)
       )
       .withValue(
-        "notifications.keepAliveInterval",
-        ConfigValueFactory.fromAnyRef(60)
-      )
-      .withValue(
         "notifications.aggregationCount",
         ConfigValueFactory.fromAnyRef(5)
       )

--- a/notifications-service/src/test/scala/com/pennsieve/notifications/api/TestRedisPubSub.scala
+++ b/notifications-service/src/test/scala/com/pennsieve/notifications/api/TestRedisPubSub.scala
@@ -110,7 +110,7 @@ class TestRedisPubSub
 
       val sinkProbe = Source(messages)
         .throttle(1, 1.second)
-        .via(SessionMonitor(1.second, authContext))
+        .via(SessionMonitor(authContext))
         .toMat(TestSink.probe[NotificationMessage])(Keep.right)
         .run()
 
@@ -131,7 +131,7 @@ class TestRedisPubSub
 
       val (sourceProbe, sinkProbe) = TestSource
         .probe[NotificationMessage]
-        .via(SessionMonitor(1.second, authContext))
+        .via(SessionMonitor(authContext))
         .toMat(TestSink.probe[NotificationMessage])(Keep.both)
         .run()
 
@@ -143,6 +143,8 @@ class TestRedisPubSub
 
       Thread.sleep(2000)
 
+      sourceProbe.sendNext(msg)
+      sinkProbe.request(n = 1)
       sinkProbe.expectError() shouldBe SessionExpired
     }
   }

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -63,12 +63,6 @@ resource "aws_ssm_parameter" "jwt_secret_key" {
   }
 }
 
-resource "aws_ssm_parameter" "keepalive_interval" {
-  name  = "/${var.environment_name}/${var.service_name}/keepalive-interval"
-  type  = "String"
-  value = var.keepalive_interval
-}
-
 resource "aws_ssm_parameter" "ping_interval" {
   name  = "/${var.environment_name}/${var.service_name}/ping-interval"
   type  = "String"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -26,10 +26,6 @@ variable "freshness_threshold" {
   default = "30"
 }
 
-variable "keepalive_interval" {
-  default = "300"
-}
-
 variable "ping_interval" {
   default = "10"
 }


### PR DESCRIPTION
Simplify `SessionMonitor` by removing keep-alive tick. Instead, check
the Cognito expiration for every message that is received. This,
combined with the `PongMonitor` will ensure that unauthenticated users
can never stay connected for longer than the timeout on the `PongMonitor`