### PR TITLE
Fix: explicitly load PGDriver for JDBC

### DIFF
--- a/notifications-service/src/main/scala/com/pennsieve/notifications/api/PostgresPubSub.scala
+++ b/notifications-service/src/main/scala/com/pennsieve/notifications/api/PostgresPubSub.scala
@@ -169,6 +169,9 @@ object PostgresPubSub extends StrictLogging {
     postgres: PostgresDatabase
   ): PGConnection = {
 
+    // Load driver
+    Class.forName("com.impossibl.postgres.jdbc.PGDriver")
+
     val jdbcUrl: String = {
       val base =
         s"jdbc:pgsql://${postgres.host}:${postgres.port}/${postgres.database}"


### PR DESCRIPTION
Try and fix "No suitable driver found for jdbc:pgsql..." error.