### PR TITLE
Fix streamed message handling

### DIFF
--- a/notifications-service/src/main/scala/com/pennsieve/notifications/api/PostgresPubSub.scala
+++ b/notifications-service/src/main/scala/com/pennsieve/notifications/api/PostgresPubSub.scala
@@ -176,7 +176,8 @@ object PostgresPubSub extends StrictLogging {
       val base =
         s"jdbc:pgsql://${postgres.host}:${postgres.port}/${postgres.database}"
 
-      if (postgres.useSSL) base + "?ssl.mode=verify-ca&ssl.ca.certificate.file=/home/pennsieve/.postgresql/root.crt"
+      if (postgres.useSSL)
+        base + "?ssl.mode=verify-ca&ssl.ca.certificate.file=/home/pennsieve/.postgresql/root.crt"
       else base
     }
 


### PR DESCRIPTION
Parse `TextMessage.Streamed` in addition to `Strict`. This is needed
because the Cognito JWT is sent in the pong body which increases the
size of the payload.