### PR TITLE
fetch updated RDS CA certificate bundle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,11 +95,20 @@ lazy val `notifications-service` = project
     dockerfile in docker := {
       val artifact: File = assembly.value
       val artifactTargetPath = s"/app/${artifact.name}"
+
+      // Where Postgres (psql/JDBC) expects to find the trusted CA certificate
+      val CA_CERT_LOCATION = "/home/pennsieve/.postgresql/root.crt"
+
       new Dockerfile {
         from("pennsieve/java-cloudwrap:10-jre-slim-0.5.9")
         copy(artifact, artifactTargetPath, chown="pennsieve:pennsieve")
-        run("mkdir", "-p", "/home/pennsieve/.postgresql")
-        run("wget", "-qO", "/home/pennsieve/.postgresql/root.crt", "https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem")
+        addRaw(
+          "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
+          CA_CERT_LOCATION,
+        )
+        user("root")
+        run("chmod", "+r", CA_CERT_LOCATION)
+        user("pennsieve")
         cmd(
           "--service",
           "notifications-service",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.3
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ credentials += Credentials(
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.11.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 


### PR DESCRIPTION
## Description
**ClickUp Ticket:** [8688dguvj](https://app.clickup.com/t/8688dguvj)

Upgrading the CA we pull down to trust when connecting to our PostgreSQL database using `ssl_mode=verify-ca`. The old CA is set to expire in August 2024 so we will need to upgrade our RDS CA. This change allows us to do that without introducing downtime.

## Testing
Built and ran the images locally to ensure the new CA cert bundle was put in the right location.

Tested using the bundle separately:
- locally (from the dev jump box) using the bundled PEM in place of the single expiring certificate.
- with a JDBC connection via the pennsieve-api repo in: https://github.com/Pennsieve/pennsieve-api/pull/287